### PR TITLE
fix: parse grade when /100 is omitted

### DIFF
--- a/main6.py
+++ b/main6.py
@@ -352,7 +352,7 @@ Now, grade this essay:
         m = re.search(rf'\b{crit}\b\s*[:\-]?\s*(\d{{1,3}})', ai_response, re.I)
         scores[crit.lower()] = m.group(1) if m else "N/A"
 
-    grade_match = re.search(r'\bGrade\b\s*[:\-]?\s*(\d{1,3})\s*/\s*100', ai_response, re.I)
+    grade_match = re.search(r'\bGrade\b\s*[:\-]?\s*(\d{1,3})(?:\s*/\s*100)?', ai_response, re.I)
     grade = grade_match.group(1) if grade_match else "N/A"
 
     return JSONResponse(content={

--- a/main6_revised.py
+++ b/main6_revised.py
@@ -459,8 +459,8 @@ Now, grade this essay strictly following all the rules above:
         detailed_scores[crit.lower()] = m.group(1) if m else "N/A"
 
     # Parse grade (search within the whole response)
-    # Regex: Look for "Grade", optional colon, optional space, digits, slash, 100
-    grade_match = re.search(r'^\s*Grade\s*:\s*(\d{1,3})\s*/\s*100\s*$', ai_response, re.IGNORECASE | re.MULTILINE)
+    # Regex: Look for "Grade", optional colon, optional space, digits, optional /100
+    grade_match = re.search(r'^\s*Grade\s*:\s*(\d{1,3})(?:\s*/\s*100)?\s*$', ai_response, re.IGNORECASE | re.MULTILINE)
     grade = grade_match.group(1) if grade_match else "N/A"
 
     # Parse Strengths, Weaknesses, and Suggestions


### PR DESCRIPTION
## Summary
- tweak regex in `main6.py` and `main6_revised.py` to accept grades without `/100`

## Testing
- `python -m py_compile main6.py main6_revised.py`


------
https://chatgpt.com/codex/tasks/task_b_684a23f7d6288327bba7559331275bcd