### PR TITLE
Add grade parsing unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ pip install fastapi requests weasyprint uvicorn python-multipart<br>
 
 ▶️ Run the App<br>
 uvicorn main6:app --reload<br>
+
+🧪 **Run Tests**
+Install pytest and execute the test suite:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/test_grade_parsing.py
+++ b/tests/test_grade_parsing.py
@@ -1,0 +1,16 @@
+import re
+
+GRADE_RE = re.compile(r"\bGrade\b\s*[:\-]?\s*(\d{1,3})(?:\s*/\s*100)?", re.I)
+
+def parse_grade(text: str):
+    match = GRADE_RE.search(text)
+    return match.group(1) if match else None
+
+def test_parse_grade_with_total():
+    assert parse_grade("Grade: 90/100") == "90"
+
+def test_parse_grade_without_total():
+    assert parse_grade("Grade: 90") == "90"
+
+def test_parse_grade_unrelated_text():
+    assert parse_grade("No grade here") is None


### PR DESCRIPTION
## Summary
- add pytest for grade regex behavior
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684a250d94f88327bc655fccb7496813